### PR TITLE
Add release workflow for Debian package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential dpkg-dev
+      - name: Configure
+        run: ./configure
+      - name: Build Debian package
+        run: make deb
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./Concreto.deb
+          asset_name: Concreto.deb
+          asset_content_type: application/vnd.debian.binary-package
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow triggered on new releases
- build `.deb` package and attach it as a release asset

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684c26cf9230832db6fd892ab9c84b5a