### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build-deb:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant write permissions in the release workflow for uploading assets

## Testing
- `./configure`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684c297adc98832daceaa6b6097b9354