### PR TITLE
Add manpage installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin
+MANDIR = $(PREFIX)/share/man/man1
 CC = gcc
 CFLAGS = -Wall -Wextra -O2
 VERSION ?= 1.0
@@ -18,7 +19,7 @@ concreto.o: concreto.c concreto.h
 concreto_test: concreto_test.c concreto.c concreto.h
 	$(CC) $(CFLAGS) -DUNIT_TEST -o $@ concreto_test.c concreto.c -lm
 
-.PHONY: test
+.PHONY: test manpage
 
 test: concreto_test
 	./concreto_test
@@ -26,6 +27,11 @@ test: concreto_test
 install: concreto
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 755 concreto $(DESTDIR)$(BINDIR)/concreto
+
+manpage:
+	install -d $(DESTDIR)$(MANDIR)
+	install -m 644 concreto.1 $(DESTDIR)$(MANDIR)/concreto.1
+	gzip -f $(DESTDIR)$(MANDIR)/concreto.1
 
 clean:
 	rm -f concreto concreto_test *.o
@@ -35,6 +41,7 @@ clean:
 
 deb: clean all
 	mkdir -p debian/DEBIAN debian$(BINDIR)
+	mkdir -p debian$(MANDIR)
 	echo 'Package: concreto' > debian/DEBIAN/control
 	echo 'Version: $(VERSION)' >> debian/DEBIAN/control
 	echo 'Section: utils' >> debian/DEBIAN/control
@@ -43,4 +50,6 @@ deb: clean all
 	echo 'Maintainer: Unknown <unknown@example.com>' >> debian/DEBIAN/control
 	echo 'Description: Concreto computes concrete mix material quantities.' >> debian/DEBIAN/control
 	install -m 755 concreto debian$(BINDIR)/concreto
+	install -m 644 concreto.1 debian$(MANDIR)/concreto.1
+	gzip -f debian$(MANDIR)/concreto.1
 	dpkg-deb --build debian Concreto.deb

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ sudo make install
 
 O executável será copiado para `$(PREFIX)/bin`.
 
+Para instalar a página de manual utilize:
+
+```bash
+sudo make manpage
+```
+
 ## Criação do pacote Debian
 
 É possível gerar um pacote `.deb` executando:
@@ -40,6 +46,8 @@ O arquivo `Concreto.deb` será criado e pode ser instalado com:
 ```bash
 sudo dpkg -i Concreto.deb
 ```
+
+O pacote já inclui a página de manual em `man1/concreto.1.gz`.
 
 ## Uso
 


### PR DESCRIPTION
## Summary
- add manpage path and target in the Makefile
- package the manual page in the `.deb`
- document manual installation in the README

## Testing
- `./configure`
- `make`
- `make test`
- `make manpage DESTDIR=/tmp/testroot`
- `make deb`


------
https://chatgpt.com/codex/tasks/task_e_684c2df3da14832d929d0d3832ef02db