### PR TITLE
Add Concreto GUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential dpkg-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential dpkg-dev qtbase5-dev
       - name: Configure
         run: ./configure
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential dpkg-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential dpkg-dev qtbase5-dev
       - name: Configure
         run: ./configure
       - name: Build Debian package

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ MANDIR = $(PREFIX)/share/man/man1
 DESKTOPDIR = $(PREFIX)/share/applications
 CC = gcc
 CXX = g++
-CFLAGS = -Wall -Wextra -O2
-CXXFLAGS = -Wall -Wextra -O2
+CFLAGS = -Wall -Wextra -O2 -fPIC
+CXXFLAGS = -Wall -Wextra -O2 -fPIC
 QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets 2>/dev/null || pkg-config --cflags Qt5Widgets)
 QT_LIBS := $(shell pkg-config --libs Qt6Widgets 2>/dev/null || pkg-config --libs Qt5Widgets)
 VERSION ?= 1.0
@@ -76,6 +76,7 @@ deb: clean all
 	echo 'Section: utils' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Priority: optional' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Architecture: amd64' >> $(BUILDDIR)/debian/DEBIAN/control
+	echo 'Depends: libc6 (>= 2.34), libqt5widgets5 (>= 5.15)' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Maintainer: Unknown <unknown@example.com>' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Description: Concreto computes concrete mix material quantities.' >> $(BUILDDIR)/debian/DEBIAN/control
 	install -m 755 $(OUTDIR)/concreto $(BUILDDIR)/debian$(BINDIR)/concreto

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,13 @@
 PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin
 MANDIR = $(PREFIX)/share/man/man1
+DESKTOPDIR = $(PREFIX)/share/applications
 CC = gcc
+CXX = g++
 CFLAGS = -Wall -Wextra -O2
+CXXFLAGS = -Wall -Wextra -O2
+QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets 2>/dev/null || pkg-config --cflags Qt5Widgets)
+QT_LIBS := $(shell pkg-config --libs Qt6Widgets 2>/dev/null || pkg-config --libs Qt5Widgets)
 VERSION ?= 1.0
 
 SRCDIR = src
@@ -13,8 +18,9 @@ OBJDIR = $(BUILDDIR)/obj
 OUTDIR = $(BUILDDIR)
 
 OBJS = $(OBJDIR)/concreto.o
+OBJS_GUI = $(OBJDIR)/concreto_nom.o
 
-all: $(OUTDIR)/concreto
+all: $(OUTDIR)/concreto $(OUTDIR)/concreto-gui
 
 $(OBJDIR):
 	mkdir -p $@
@@ -25,22 +31,31 @@ $(OUTDIR):
 $(OUTDIR)/concreto: $(OBJS) | $(OUTDIR)
 	$(CC) $(CFLAGS) -o $@ $(OBJS) -lm
 
+$(OUTDIR)/concreto-gui: $(OBJS_GUI) $(SRCDIR)/gui/main.cpp | $(OUTDIR)
+	$(CXX) $(CXXFLAGS) $(QT_CFLAGS) -o $@ $(SRCDIR)/gui/main.cpp $(OBJS_GUI) $(QT_LIBS) -lm
+
 $(OBJDIR)/concreto.o: $(SRCDIR)/concreto.c $(SRCDIR)/concreto.h | $(OBJDIR)
 	$(CC) $(CFLAGS) -c -o $@ $(SRCDIR)/concreto.c
+
+$(OBJDIR)/concreto_nom.o: $(SRCDIR)/concreto.c $(SRCDIR)/concreto.h | $(OBJDIR)
+	$(CC) $(CFLAGS) -DWITHOUT_MAIN -c -o $@ $(SRCDIR)/concreto.c
 
 $(OUTDIR)/concreto_test: $(SRCDIR)/concreto_test.c $(SRCDIR)/concreto.c \
 $(SRCDIR)/concreto.h | $(OUTDIR)
 	$(CC) $(CFLAGS) -DUNIT_TEST -o $@ $(SRCDIR)/concreto_test.c \
-$(SRCDIR)/concreto.c -lm
+	$(SRCDIR)/concreto.c -lm
 
 .PHONY: test manpage
 
 test: $(OUTDIR)/concreto_test
 	$(OUTDIR)/concreto_test
 
-install: $(OUTDIR)/concreto
+install: $(OUTDIR)/concreto $(OUTDIR)/concreto-gui
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 755 $(OUTDIR)/concreto $(DESTDIR)$(BINDIR)/concreto
+	install -m 755 $(OUTDIR)/concreto-gui $(DESTDIR)$(BINDIR)/concreto-gui
+	install -d $(DESTDIR)$(DESKTOPDIR)
+	install -m 644 concreto.desktop $(DESTDIR)$(DESKTOPDIR)/concreto.desktop
 
 manpage:
 	install -d $(DESTDIR)$(MANDIR)
@@ -55,6 +70,7 @@ clean:
 deb: clean all
 	mkdir -p $(BUILDDIR)/debian/DEBIAN $(BUILDDIR)/debian$(BINDIR)
 	mkdir -p $(BUILDDIR)/debian$(MANDIR)
+	mkdir -p $(BUILDDIR)/debian$(DESKTOPDIR)
 	echo 'Package: concreto' > $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Version: $(VERSION)' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Section: utils' >> $(BUILDDIR)/debian/DEBIAN/control
@@ -63,6 +79,8 @@ deb: clean all
 	echo 'Maintainer: Unknown <unknown@example.com>' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Description: Concreto computes concrete mix material quantities.' >> $(BUILDDIR)/debian/DEBIAN/control
 	install -m 755 $(OUTDIR)/concreto $(BUILDDIR)/debian$(BINDIR)/concreto
+	install -m 755 $(OUTDIR)/concreto-gui $(BUILDDIR)/debian$(BINDIR)/concreto-gui
 	install -m 644 concreto.1 $(BUILDDIR)/debian$(MANDIR)/concreto.1
 	gzip -f $(BUILDDIR)/debian$(MANDIR)/concreto.1
+	install -m 644 concreto.desktop $(BUILDDIR)/debian$(DESKTOPDIR)/concreto.desktop
 	dpkg-deb --build $(BUILDDIR)/debian $(BUILDDIR)/Concreto.deb

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ sudo make install
 ```
 
 O executável será copiado para `$(PREFIX)/bin`.
-O binário compilado fica disponível em `build/concreto`.
+Os binários compilados ficam disponíveis em `build/concreto` (CLI) e
+`build/concreto-gui` (interface gráfica Qt).
 
 Para instalar a página de manual utilize:
 
@@ -59,4 +60,6 @@ Execute passando o traço no formato `a-b-c`, a granulometria do agregado graúd
 ```
 
 O programa exibirá as quantidades de cimento, água, areia e brita necessárias para produzir o volume informado. Os volumes são mostrados em litros.
+
+Também é possível utilizar a interface gráfica executando `concreto-gui` após a instalação ou abrindo o atalho criado pelo pacote.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Programa em C para calcular os materiais de um traço de concreto.
 
+## Dependências
+
+Para compilar a interface gráfica é necessário ter as bibliotecas de desenvolvimento do Qt instaladas (pacote `qtbase5-dev` no Debian/Ubuntu).
+
 ## Compilação e testes
 
 Primeiro execute o script `configure` para definir o prefixo de instalação (padrão `/usr/local`):

--- a/concreto.desktop
+++ b/concreto.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Concreto
+Exec=concreto-gui
+Comment=Concrete mix calculator
+Terminal=false
+Categories=Utility;

--- a/src/concreto.c
+++ b/src/concreto.c
@@ -39,7 +39,7 @@ Masses compute_masses(Volumes volumes, double granulometry) {
     return m;
 }
 
-#ifndef UNIT_TEST
+#if !defined(UNIT_TEST) && !defined(WITHOUT_MAIN)
 int main(int argc, char *argv[]) {
     if (argc != 4) {
         fprintf(stderr, "Uso: %s <traco a-b-c> <granulometria_mm> <volume_m3>\n", argv[0]);

--- a/src/concreto.h
+++ b/src/concreto.h
@@ -1,6 +1,10 @@
 #ifndef CONCRETO_H
 #define CONCRETO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DENSITY_CEMENT 1440.0
 #define DENSITY_SAND 1600.0
 #define DENSITY_GRAVEL 1550.0
@@ -29,5 +33,9 @@ int parse_ratio(const char *str, MixRatio *ratio);
 double wc_ratio(double granulometry);
 Volumes compute_volumes(double total_volume, MixRatio ratio);
 Masses compute_masses(Volumes volumes, double granulometry);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CONCRETO_H

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -1,0 +1,79 @@
+#include <QApplication>
+#include <QWidget>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include "../concreto.h"
+
+class ConcretoWindow : public QWidget {
+public:
+    ConcretoWindow(QWidget *parent = nullptr) : QWidget(parent) {
+        auto *layout = new QVBoxLayout(this);
+        auto *form = new QFormLayout();
+        ratioEdit = new QLineEdit();
+        granulEdit = new QLineEdit();
+        volumeEdit = new QLineEdit();
+        form->addRow("Traço (a-b-c):", ratioEdit);
+        form->addRow("Granulometria (mm):", granulEdit);
+        form->addRow("Volume (m³):", volumeEdit);
+        layout->addLayout(form);
+        auto *btnLayout = new QHBoxLayout();
+        runButton = new QPushButton("Run");
+        closeButton = new QPushButton("Close");
+        btnLayout->addWidget(runButton);
+        btnLayout->addWidget(closeButton);
+        layout->addLayout(btnLayout);
+        resultArea = new QTextEdit();
+        resultArea->setReadOnly(true);
+        layout->addWidget(resultArea);
+
+        connect(runButton, &QPushButton::clicked, this, &ConcretoWindow::run);
+        connect(closeButton, &QPushButton::clicked, qApp, &QApplication::quit);
+        setWindowTitle("Concreto");
+    }
+
+private slots:
+    void run() {
+        MixRatio ratio;
+        if (!parse_ratio(ratioEdit->text().toUtf8().constData(), &ratio)) {
+            resultArea->setText("Formato de traço inválido.");
+            return;
+        }
+        bool ok1, ok2;
+        double granul = granulEdit->text().toDouble(&ok1);
+        double volume = volumeEdit->text().toDouble(&ok2);
+        if (!ok1 || !ok2 || granul <= 0 || volume <= 0) {
+            resultArea->setText("Valores inválidos.");
+            return;
+        }
+        Volumes vols = compute_volumes(volume, ratio);
+        Masses masses = compute_masses(vols, granul);
+        double water_vol = masses.water / DENSITY_WATER;
+
+        QString res;
+        res += QString("Cimento: %1 kg (%2 L)\n").arg(masses.cement, 0, 'f', 2).arg(vols.cement * 1000.0, 0, 'f', 2);
+        res += QString("Agua: %1 kg (%2 L)\n").arg(masses.water, 0, 'f', 2).arg(water_vol * 1000.0, 0, 'f', 2);
+        res += QString("Areia: %1 kg (%2 L)\n").arg(masses.sand, 0, 'f', 2).arg(vols.sand * 1000.0, 0, 'f', 2);
+        res += QString("Brita: %1 kg (%2 L)\n").arg(masses.gravel, 0, 'f', 2).arg(vols.gravel * 1000.0, 0, 'f', 2);
+        resultArea->setText(res);
+    }
+
+private:
+    QLineEdit *ratioEdit;
+    QLineEdit *granulEdit;
+    QLineEdit *volumeEdit;
+    QPushButton *runButton;
+    QPushButton *closeButton;
+    QTextEdit *resultArea;
+};
+
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    ConcretoWindow w;
+    w.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- add Qt-based GUI in `concreto-gui`
- wrap C API for C++ and guard CLI main with `WITHOUT_MAIN`
- compile GUI and include in install and deb package
- add desktop file for integration
- document new GUI usage in README

## Testing
- `./configure`
- `make`
- `make test`
- `make deb`

------
https://chatgpt.com/codex/tasks/task_e_684c35304218832d9b924c0a36577812