### PR TITLE
Fix QT dependencies for CI and package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential dpkg-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential dpkg-dev qtbase5-dev
       - name: Configure
         run: ./configure
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential dpkg-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential dpkg-dev qtbase5-dev
       - name: Configure
         run: ./configure
       - name: Build Debian package

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ MANDIR = $(PREFIX)/share/man/man1
 DESKTOPDIR = $(PREFIX)/share/applications
 CC = gcc
 CXX = g++
-CFLAGS = -Wall -Wextra -O2
-CXXFLAGS = -Wall -Wextra -O2
+CFLAGS = -Wall -Wextra -O2 -fPIC
+CXXFLAGS = -Wall -Wextra -O2 -fPIC
 QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets 2>/dev/null || pkg-config --cflags Qt5Widgets)
 QT_LIBS := $(shell pkg-config --libs Qt6Widgets 2>/dev/null || pkg-config --libs Qt5Widgets)
 VERSION ?= 1.0
@@ -76,6 +76,7 @@ deb: clean all
 	echo 'Section: utils' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Priority: optional' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Architecture: amd64' >> $(BUILDDIR)/debian/DEBIAN/control
+	echo 'Depends: libc6 (>= 2.34), libqt5widgets5 (>= 5.15)' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Maintainer: Unknown <unknown@example.com>' >> $(BUILDDIR)/debian/DEBIAN/control
 	echo 'Description: Concreto computes concrete mix material quantities.' >> $(BUILDDIR)/debian/DEBIAN/control
 	install -m 755 $(OUTDIR)/concreto $(BUILDDIR)/debian$(BINDIR)/concreto

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Programa em C para calcular os materiais de um traço de concreto.
 
+## Dependências
+
+Para compilar a interface gráfica é necessário ter as bibliotecas de desenvolvimento do Qt instaladas (pacote `qtbase5-dev` no Debian/Ubuntu).
+
 ## Compilação e testes
 
 Primeiro execute o script `configure` para definir o prefixo de instalação (padrão `/usr/local`):


### PR DESCRIPTION
## Summary
- add Qt dev package in CI and release workflows
- link with PIC, add package Depends line
- document Qt dependency

## Testing
- `make`
- `make test`
- `make deb`

------
https://chatgpt.com/codex/tasks/task_e_684c8f8649a0832da31f1a45c35ff989